### PR TITLE
hw6-3 checker fix

### DIFF
--- a/2018/hw6/ex3/check
+++ b/2018/hw6/ex3/check
@@ -33,7 +33,7 @@ do
 
     printf "Test %s..." "${TC}"
 
-    COMM="./run -resonly ${TFILE}.m > ${TFILE}.out"
+    COMM="./run ${TFILE}.m > ${TFILE}.out"
     if [ -f "${TFILE}.in" ]
     then
         COMM="${COMM} < ${TFILE}.in"

--- a/2018/hw6/ex3/main.ml
+++ b/2018/hw6/ex3/main.ml
@@ -56,7 +56,6 @@ let run () =
       let _ = M_Printer.print pgm in
       print_newline()
     );
-    let _ = print_string "== Running with M Interpreter ==\n" in
     M.run pgm
   with v -> Error.handle_exn v
 


### PR DESCRIPTION
resonly 옵션을 제거했습니다. resonly 옵션이 없으면 실행이 되기는 하는데 제대로 체커가 작동하는지는 잘 모르겠긴 합니다...