### PR TITLE
뼈대코드에는 MIT 라이센스를 적용하지 않음

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+각 과제의 뼈대코드의 저작권은 전적으로 각 과제 README.md 하단에 적혀있는 조교님들에게 있습니다.
+따라서 해당 뼈대코드들은 아래 License를 따르지 않습니다.
+그 외의 코드에 대해서는 아래 MIT License를 따릅니다.
+
+
 MIT License
 
 Copyright (c) 2017 Jonghun Park


### PR DESCRIPTION
이미 무단 수정 및 배포가 되어있는 상황이지만 뼈대코드를 만들어주신 조교님께 최소한의 예의를 갖춥니다.
뼈대코드는 `LICENSE` 파일에 명시되어있는 MIT License를 따르지 않습니다.